### PR TITLE
Update SchemaConverters.scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ Suppose hrt_qa is a headless account, user can use following command for kinit:
 
     /usr/hdp/current/spark-client/bin/spark-submit --class your.application.class --master yarn-cluster --files /etc/hbase/conf/hbase-site.xml --packages com.hortonworks:shc:1.0.0-1.6-s_2.10 --repositories http://repo.hortonworks.com/content/groups/public/ --num-executors 4 --driver-memory 512m --executor-memory 512m --executor-cores 1 /To/your/application/jar
 
+## Support of Avro schemas:
+The connector fully supports all the avro schemas. Users can use either a complete record schema or partial field schema as data type in their catalog.
+    
+    val schema_array = s"""{"type": "array", "items": ["string","null"]}""".stripMargin
+    val schema_record =
+      s"""{"namespace": "example.avro",
+         |   "type": "record",      "name": "User",
+         |    "fields": [      {"name": "name", "type": "string"},
+         |      {"name": "favorite_number",  "type": ["int", "null"]},
+         |        {"name": "favorite_color", "type": ["string", "null"]}      ]    }""".stripMargin
+    val catalog = s"""{
+            |"table":{"namespace":"default", "name":"htable"},
+            |"rowkey":"key1",
+            |"columns":{
+              |"col1":{"cf":"rowkey", "col":"key1", "type":"double"},
+              |"col2":{"cf":"cf1", "col":"col1", "avro":"schema_array"},
+              |"col3":{"cf":"cf1", "col":"col2", "avro":"schema_record"},
+              |"col4":{"cf":"cf1", "col":"col3", "type":"double"},
+              |"col5":{"cf":"cf1", "col":"col4", "type":"string"}
+            |}
+          |}""".stripMargin
+     val df = sqlContext.read.options(Map("schema_array"->schema_array,"schema_record"->schema_record, HBaseTableCatalog.tableCatalog->catalog)).format("org.apache.spark.sql.execution.datasources.hbase").load()
+    df.write.options(Map("schema_array"->schema_array,"schema_record"->schema_record, HBaseTableCatalog.tableCatalog->catalog)).format("org.apache.spark.sql.execution.datasources.hbase").save()
+         
 #### TODO:
 
     val complex = s"""MAP<int, struct<varchar:string>>"""

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SchemaConverters.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SchemaConverters.scala
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer
 import java.sql.Timestamp
 import java.util
 import java.util.HashMap
+import java.io.IOException
 
 import scala.collection.immutable.Map
 import scala.collection.JavaConversions._
@@ -380,25 +381,20 @@ object SchemaConverters {
 
 
 object AvroSedes {
-  // We only handle top level is record or primary type now
   def serialize(input: Any, schema: Schema): Array[Byte]= {
-    schema.getType match {
-      case BOOLEAN => Bytes.toBytes(input.asInstanceOf[Boolean])
-      case BYTES | FIXED => input.asInstanceOf[Array[Byte]]
-      case DOUBLE => Bytes.toBytes(input.asInstanceOf[Double])
-      case FLOAT => Bytes.toBytes(input.asInstanceOf[Float])
-      case INT => Bytes.toBytes(input.asInstanceOf[Int])
-      case LONG => Bytes.toBytes(input.asInstanceOf[Long])
-      case STRING => Bytes.toBytes(input.asInstanceOf[String])
-      case RECORD =>
-        val gr = input.asInstanceOf[GenericRecord]
-        val writer2 = new GenericDatumWriter[GenericRecord](schema)
-        val bao2 = new ByteArrayOutputStream()
-        val encoder2: BinaryEncoder = EncoderFactory.get().directBinaryEncoder(bao2, null)
-        writer2.write(gr, encoder2)
-        bao2.toByteArray()
-      case _ => throw new Exception(s"unsupported data type ${schema.getType}") //TODO
-    }
+	  val bao = new ByteArrayOutputStream()
+    try {
+	    val writer = new GenericDatumWriter[Any](schema)  
+	    val encoder: BinaryEncoder = EncoderFactory.get().directBinaryEncoder(bao, null)
+	    writer.write(input, encoder)
+	    bao.toByteArray()
+	  } catch {
+	    case e: IOException => throw new Exception(s"Exception while creating byte array for Avro schema ${schema}")
+	  } finally {
+	    if(bao != null) {
+		    bao.close()
+	    }
+	  }
   }
 
   def deserialize(input: Array[Byte], schema: Schema): Any = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SchemaConverters.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SchemaConverters.scala
@@ -382,19 +382,19 @@ object SchemaConverters {
 
 object AvroSedes {
   def serialize(input: Any, schema: Schema): Array[Byte]= {
-	  val bao = new ByteArrayOutputStream()
+    val bao = new ByteArrayOutputStream()
     try {
-	    val writer = new GenericDatumWriter[Any](schema)  
-	    val encoder: BinaryEncoder = EncoderFactory.get().directBinaryEncoder(bao, null)
-	    writer.write(input, encoder)
-	    bao.toByteArray()
-	  } catch {
-	    case e: IOException => throw new Exception(s"Exception while creating byte array for Avro schema ${schema}")
-	  } finally {
-	    if(bao != null) {
-		    bao.close()
-	    }
-	  }
+      val writer = new GenericDatumWriter[Any](schema)  
+      val encoder: BinaryEncoder = EncoderFactory.get().directBinaryEncoder(bao, null)
+      writer.write(input, encoder)
+      bao.toByteArray()
+    } catch {
+      case e: IOException => throw new Exception(s"Exception while creating byte array for Avro schema ${schema}")
+    } finally {
+      if(bao != null) {
+	 bao.close()
+      }
+    }
   }
 
   def deserialize(input: Array[Byte], schema: Schema): Any = {

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SchemaConverters.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/SchemaConverters.scala
@@ -401,11 +401,11 @@ object AvroSedes {
     }
   }
 
-  def deserialize(input: Array[Byte], schema: Schema): GenericRecord = {
-    val reader2: DatumReader[GenericRecord] = new GenericDatumReader[GenericRecord](schema)
+  def deserialize(input: Array[Byte], schema: Schema): Any = {
+    val reader2: DatumReader[Any] = new GenericDatumReader[Any](schema)
     val bai2 = new ByteArrayInputStream(input)
     val decoder2: BinaryDecoder = DecoderFactory.get().directBinaryDecoder(bai2, null)
-    val gr2: GenericRecord = reader2.read(null, decoder2)
-    gr2
+    val res: Any = reader2.read(null, decoder2)
+    res
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
@@ -67,15 +67,15 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
       p.parse(schemaString)
     }
 
-	  val data = new java.util.ArrayList[Any]
-	  data.add(1)
-	  data.add(2)
-	  data.add(null)
-	  data.add(-3)
+    val data = new java.util.ArrayList[Any]
+    data.add(1)
+    data.add(2)
+    data.add(null)
+    data.add(-3)
 	  
-	  val sqlConv = SchemaConverters.createConverterToSQL(avroSchema)(data)
-	  println(sqlConv)
-	  val sqlSchema = SchemaConverters.toSqlType(avroSchema)
+    val sqlConv = SchemaConverters.createConverterToSQL(avroSchema)(data)
+    println(sqlConv)
+    val sqlSchema = SchemaConverters.toSqlType(avroSchema)
     println(s"\nSqlschema: $sqlSchema")
     val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, "avro", "example.avro")(sqlConv)
     val avroBytes = AvroSedes.serialize(avroData, avroSchema)
@@ -90,10 +90,10 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
       p.parse(schemaString)
     }
 
-	  val data = -1234.93f
-	  val sqlConv = SchemaConverters.createConverterToSQL(avroSchema)(data)
-	  println(sqlConv)
-	  val sqlSchema = SchemaConverters.toSqlType(avroSchema)
+    val data = -1234.93f
+    val sqlConv = SchemaConverters.createConverterToSQL(avroSchema)(data)
+    println(sqlConv)
+    val sqlSchema = SchemaConverters.toSqlType(avroSchema)
     println(s"\nSqlschema: $sqlSchema")
     val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, "avro", "example.avro")(sqlConv)
     val avroBytes = AvroSedes.serialize(avroData, avroSchema)

--- a/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AvroRecordSuite.scala
@@ -60,6 +60,47 @@ class AvroRecordSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAft
     println(s"$avroUser1")
   }
 
+  test("avro array type schema serialize/deserialize") {
+    val schemaString  =  s"""{"type": "array", "items": ["int","null"]}""".stripMargin
+    val avroSchema: Schema = {
+      val p = new Schema.Parser
+      p.parse(schemaString)
+    }
+
+	  val data = new java.util.ArrayList[Any]
+	  data.add(1)
+	  data.add(2)
+	  data.add(null)
+	  data.add(-3)
+	  
+	  val sqlConv = SchemaConverters.createConverterToSQL(avroSchema)(data)
+	  println(sqlConv)
+	  val sqlSchema = SchemaConverters.toSqlType(avroSchema)
+    println(s"\nSqlschema: $sqlSchema")
+    val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, "avro", "example.avro")(sqlConv)
+    val avroBytes = AvroSedes.serialize(avroData, avroSchema)
+    val desData = AvroSedes.deserialize(avroBytes, avroSchema)
+    println(s"$desData")
+  }
+	
+  test("avro flaot type union schema serialize/deserialize") {
+    val schemaString  =  s"""["float","null"]""".stripMargin
+    val avroSchema: Schema = {
+      val p = new Schema.Parser
+      p.parse(schemaString)
+    }
+
+	  val data = -1234.93f
+	  val sqlConv = SchemaConverters.createConverterToSQL(avroSchema)(data)
+	  println(sqlConv)
+	  val sqlSchema = SchemaConverters.toSqlType(avroSchema)
+    println(s"\nSqlschema: $sqlSchema")
+    val avroData = SchemaConverters.createConverterToAvro(sqlSchema.dataType, "avro", "example.avro")(sqlConv)
+    val avroBytes = AvroSedes.serialize(avroData, avroSchema)
+    val desData = AvroSedes.deserialize(avroBytes, avroSchema)
+    println(s"$desData")
+  }
+
   test("test schema complicated") {
     val schemaString =
       s"""{


### PR DESCRIPTION
If the reader returns Object instead of GenericRecord the deserialize method will support all of the avro schemas. It currently casts to GenericRecord and it doesn't work for simple type and union schemas.